### PR TITLE
Upgrade for django 2.2 and version bump

### DIFF
--- a/eventlog/__init__.py
+++ b/eventlog/__init__.py
@@ -1,2 +1,2 @@
 # following PEP 386
-__version__ = "0.6.6"
+__version__ = "0.6.7"

--- a/eventlog/models.py
+++ b/eventlog/models.py
@@ -28,7 +28,7 @@ class Log(models.Model):
 
 
 def log(user, action, extra=None):
-    if (user is not None and not user.is_authenticated()):
+    if (user is not None and not user.is_authenticated):
         user = None
     if extra is None:
         extra = {}


### PR DESCRIPTION
Update `is_authenticated()` to `is_authenticated` so that Django 2.2 migration is possible.

